### PR TITLE
Add search parameter on facility orchestrator

### DIFF
--- a/src/main/java/tz/go/moh/him/hfr/mediator/orchestrator/FacilityOrchestrator.java
+++ b/src/main/java/tz/go/moh/him/hfr/mediator/orchestrator/FacilityOrchestrator.java
@@ -15,6 +15,8 @@ import org.json.JSONObject;
 import org.openhim.mediator.engine.MediatorConfig;
 import org.openhim.mediator.engine.messages.MediatorHTTPRequest;
 import org.openhim.mediator.engine.messages.MediatorHTTPResponse;
+import org.openhim.mediator.engine.messages.PutPropertyInCoreResponse;
+
 import tz.go.moh.him.hfr.mediator.domain.HfrRequest;
 
 import java.nio.charset.StandardCharsets;
@@ -63,6 +65,12 @@ public class FacilityOrchestrator extends UntypedActor {
             workingRequest = (MediatorHTTPRequest) msg;
 
             log.info("Received request: " + workingRequest.getHost() + " " + workingRequest.getMethod() + " " + workingRequest.getPath());
+            // Add Search parameter to the request
+            String body = workingRequest.getBody();
+            JSONObject payload = new JSONObject(body);
+            
+            String facilityCode = payload.getString("Fac_IDNumber");
+            workingRequest.getRequestHandler().tell(new PutPropertyInCoreResponse("facility_code", facilityCode), getSelf());
 
             Map<String, String> headers = new HashMap<>();
 


### PR DESCRIPTION
Add `facility_code ` as a search parameter for HFR request passing through HIM with its value being `Fac_IDNumber` of facility from HFR